### PR TITLE
Rely on YNAB transactions' cleared state to match them

### DIFF
--- a/auto_sync.py
+++ b/auto_sync.py
@@ -108,7 +108,6 @@ def setup_callback():
             return
         callback_port = portmap_port
 
-    sync_obj.populate()
     for acc in sync_obj.get_bunq_accounts():
         url = "https://{}:{}/bunq2ynab-autosync".format(
                                                     callback_ip, callback_port)
@@ -173,6 +172,7 @@ try:
     while True:
         try:
             sync_obj = sync.Sync()
+            sync_obj.populate()
 
             setup_callback()
 


### PR DESCRIPTION
This changeset supports entering manual transactions in YNAB prior to
having the connector match up the bank statement. It consists of two
changes:
    
1- Retrieve bunq transactions as far back as the oldest uncleared
   transaction in YNAB; and,
2- Make sure to match any existing transaction that is still
   uncleared.
    
Note that we do not update existing transactions but rather submit
new transactions with a matching import-id to let YNAB handle the
actual matching. This approach gives a clue to the customer as to when
a manually entered transactions gets matched (YNAB shows the "matched icon"
and requires the match to be approved).
    
Fixes: #34

---

This fix allows budgeters to manually enter transactions in YNAB and still get them matched by the script when they show up in bunq.

Note that transactions can be in three states: "cleared", "uncleared", and "reconciled".
I found it was 1) easier to read, and 2) simpler to shuffle the "is the transaction new" logic in `lib/sync.py#129`.