### PR TITLE
Auto-approve new transactions

### DIFF
--- a/lib/sync.py
+++ b/lib/sync.py
@@ -134,6 +134,8 @@ class Sync:
             # uncleared transaction.
             if transaction and transaction["cleared"] != "uncleared":
                 transaction["payment"] = p
+                transaction["approved"] = True
+                transaction["dirty"] = True                
             else:
                 # YNAB payee is max 50 chars 
                 new_trans = {
@@ -143,6 +145,7 @@ class Sync:
                     "amount": milliunits,
                     "memo": p["description"][:100],  # YNAB memo max 100 chars
                     "cleared": "cleared",
+                    "approved": True,
                     "payment": p,
                     "new": True
                 }


### PR DESCRIPTION
YNAB changed it's (mobile) UI and is now prompting unapproved transactions to be reviewed as well. This used to be only uncategorized transactions. Because I never use this approval function since I've been using bunq2ynab, I wanted to auto-approve all new transactions. You might find this useful as well. 