### PR TITLE
Refresh bunq session on 'Insufficient authentication' too

### DIFF
--- a/lib/bunq.py
+++ b/lib/bunq.py
@@ -212,7 +212,7 @@ def call(action, method, data=None):
         return result
     if "Error" in result:
         descr = result["Error"][0]["error_description"]
-        if descr == "Insufficient authorisation.":
+        if descr in ("Insufficient authorisation.", "Insufficient authentication."):
             state.set("session_token", "")
             result = call_requests(action, method, data)
             if isinstance(result, str):


### PR DESCRIPTION
When the session token expires, bunq's API can return either `Insufficient authorisation.` or `Insufficient authentication.`. The retry logic only refreshed the session on the former, so requests that received the latter wording failed permanently instead of refreshing and retrying. Handles both