### PR TITLE
Add Docker deployment (Dockerfile and docker-compose)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+CMD ["python", "./auto_sync.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  bunq2ynab:
+    build: .
+    container_name: bunq2ynab
+    restart: unless-stopped
+    environment:
+      - TZ=Europe/Amsterdam
+      - PYTHONUNBUFFERED=1
+    volumes:
+      - ./config.json:/usr/src/app/config.json:ro
+      - ./state.json:/usr/src/app/state.json


### PR DESCRIPTION
Adds a minimal container setup for running the automatic sync:

- `Dockerfile` — based on `python:3.12-slim`, installs `requirements.txt` and
  runs `auto_sync.py`. 
- `docker-compose.yml` — mounts `config.json` (read-only) and `state.json`,
  with `restart: unless-stopped` and a configurable `TZ`.