### PR TITLE
Add payee name cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,28 @@ Optionally you can configure number of errors that occur before a mail is sent (
   "smtp_to": "example@gmail.com"
 ```
 
+## Payee name cleanup
+
+Banks put noisy merchant descriptors in the counterparty name of card and
+online payments, such as `BCK*Lahore Catering`, `CCV*GEBAKSKRAAM DE VRI`,
+`HEMA EV0027`, `ZEEMAN LEEUWARDEN NWE` or `U. Metselaar via Rabo Betaalverzoek`.
+Bunq2Ynab can clean these up before sending them to YNAB.
+
+Set `payee_cleanup` in your config:
+
+```json
+  "payee_cleanup": "rules"
+```
+
+| Value     | Behaviour                                                              |
+|-----------|-----------------------------------------------------------------------|
+| `"none"`  | Legacy behaviour: only split off anything after `" - "`.              |
+| `"rules"` | **Default.** Strip payment-processor prefixes (`BCK*`, `CCV*`, ...), payment-request suffixes (`via ... Betaalverzoek`), the city, and store/terminal codes. |
+
+The rules are conservative string transformations with no external calls; for
+example `CCV*GEBAKSKRAAM DE VRI` becomes `GEBAKSKRAAM DE VRI` and `HEMA EV0027`
+becomes `HEMA`. See `test_payee.py` for the full set of examples.
+
 ## systemd script
 
 Adding autosync as a systemd service

--- a/lib/bunq_api.py
+++ b/lib/bunq_api.py
@@ -4,6 +4,7 @@ import requests
 import json
 
 from lib import bunq
+from lib import payee
 from lib.log import log
 
 
@@ -146,18 +147,25 @@ def put_callbacks(user_id, new_notifications):
     bunq.post(method, data)
 
 
+CARD_PAYMENT_TYPES = {"MASTERCARD", "MAESTRO"}
+
+
+def map_payment(p):
+    is_card = p["type"] in CARD_PAYMENT_TYPES
+    return {
+        "amount": p["amount"]["value"],
+        "date": p["created"][:10],
+        "type": p["type"],
+        "sub_type": p["sub_type"],
+        "iban": p["counterparty_alias"]["iban"],
+        "payee": payee.clean(p["counterparty_alias"]["display_name"],
+                             description=p.get("description"), is_card=is_card),
+        "description": "" if is_card else p["description"].strip()
+    }
+
+
 def map_payments(result):
-    raw_payments = [p["Payment"] for p in result]
-    payments = map(lambda p: {
-            "amount": p["amount"]["value"],
-            "date": p["created"][:10],
-            "type": p["type"],
-            "sub_type": p["sub_type"],
-            "iban": p["counterparty_alias"]["iban"],
-            "payee": p["counterparty_alias"]["display_name"],
-            "description": p["description"].strip()
-        }, raw_payments)
-    return list(payments)
+    return [map_payment(p["Payment"]) for p in result]
 
 
 def get_payments(user_id, account_id, start_date):

--- a/lib/payee.py
+++ b/lib/payee.py
@@ -1,0 +1,101 @@
+import re
+
+# Clean up the messy merchant descriptors that banks put in the counterparty
+# name of card and online payments, e.g.
+#
+#   "BCK*Lahore Catering"      -> "Lahore Catering"
+#   "CCV*GEBAKSKRAAM DE VRI"   -> "GEBAKSKRAAM DE VRI"
+#   "HEMA EV0027"              -> "HEMA"
+#   "ZEEMAN LEEUWARDEN NWE"    -> "ZEEMAN"      (when city "Leeuwarden" is known)
+#   "U. Metselaar via Rabo Betaalverzoek" -> "U. Metselaar"
+#
+# Everything here is plain string munging with no external dependencies, so it
+# can be unit tested in isolation (see test_payee.py).
+
+
+# Payment service provider prefix, e.g. "BCK*", "CCV*", "ZTL*", "SumUp  *",
+# "iZ *", "SQ *", "PP*".  Two to nine leading characters followed by a star.
+_PSP_PREFIX = re.compile(r"^\s*[A-Za-z0-9.]{2,9}\s*\*\s*")
+
+# Payment-request boilerplate suffix, e.g. "... via Rabo Betaalverzoek",
+# "... via Tikkie", "... via iDEAL".
+_VIA_SUFFIX = re.compile(
+    r"\s+via\s+.+?\b(betaalverzoek|tikkie|ideal|payment request)\b.*$",
+    re.IGNORECASE)
+
+# Trailing terminal / store code, e.g. "HEMA EV0027", "Huiskamer MP 0172".
+# An optional short letter group, then three or more digits, at the very end.
+_TERMINAL_CODE = re.compile(r"\s+[A-Za-z]{0,3}\s?\d{3,}\s*$")
+
+# Trailing country code some descriptors carry, e.g. "Foo Bar, NL".
+_COUNTRY_SUFFIX = re.compile(r"\s*,\s*[A-Z]{2}\s*$")
+
+# The city (and country) that bunq appends to a card payment description,
+# e.g. "Baylings LEEUWARDEN, NL".  We only grab the final word before the
+# comma; that is enough to cut it (and any store code behind it) from the name.
+_CITY_IN_DESC = re.compile(r"([^\s,]+)\s*,\s*[A-Z]{2}\s*$")
+
+
+def city_from_description(description):
+    """Pull the city out of a bunq card description, or None.
+
+    bunq formats card descriptions as "<merchant> <CITY>, <CC>", so the word
+    right before the ", CC" suffix is (the tail of) the city.
+    """
+    if not description:
+        return None
+    m = _CITY_IN_DESC.search(description.strip())
+    if not m:
+        return None
+    city = m.group(1)
+    return city if len(city) >= 4 else None
+
+
+def _strip_city(name, city):
+    """Cut a known city (and anything after it) from a descriptor."""
+    if not city:
+        return name
+    m = re.search(r"\s+" + re.escape(city) + r"\b", name, re.IGNORECASE)
+    if m and m.start() >= 2:
+        return name[:m.start()]
+    return name
+
+
+def clean_rules(name, city=None):
+    """Rule-based payee clean-up.  Always returns a non-empty string when the
+    input is non-empty: if a rule would empty the name we keep the previous
+    value instead."""
+    if not name:
+        return name
+    cleaned = name.split(" - ")[0]
+    cleaned = _PSP_PREFIX.sub("", cleaned)
+    cleaned = _VIA_SUFFIX.sub("", cleaned)
+    cleaned = _strip_city(cleaned, city)
+    cleaned = _COUNTRY_SUFFIX.sub("", cleaned)
+    cleaned = _TERMINAL_CODE.sub("", cleaned)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
+    # Never return an empty payee; fall back to the bank's name.
+    return cleaned or name.split(" - ")[0].strip() or name
+
+
+def _mode():
+    # Read lazily so the pure functions above stay importable without a loaded
+    # config (e.g. from the unit tests).
+    try:
+        from lib.config import config
+        return (config.get("payee_cleanup", "rules") or "rules").lower()
+    except Exception:
+        return "rules"
+
+
+def clean(display_name, description=None, is_card=False):
+    """Public entry point used by the sync.  Honours the "payee_cleanup"
+    config setting: "none" (legacy behaviour) or "rules" (default)."""
+    if not display_name:
+        return display_name
+
+    if _mode() == "none":
+        return display_name.split(" - ")[0].strip()
+
+    city = city_from_description(description) if (is_card and description) else None
+    return clean_rules(display_name, city=city)

--- a/test_payee.py
+++ b/test_payee.py
@@ -1,0 +1,75 @@
+"""Unit tests for lib/payee.py rule-based clean-up.
+
+Run directly (no dependencies):   python3 test_payee.py
+Or with pytest:                    pytest test_payee.py
+"""
+from lib.payee import clean_rules, city_from_description
+
+
+# (display_name, card description or None, expected payee) -- the descriptions
+# are real bunq card descriptors captured from payments on 2026-05-29.
+CASES = [
+    ("Baylings",                "Baylings LEEUWARDEN, NL\n",                 "Baylings"),
+    ("ZEEMAN LEEUWARDEN NWE",   "ZEEMAN LEEUWARDEN NWE LEEUWARDEN, NL",      "ZEEMAN"),
+    ("HEMA EV0027",             "HEMA EV0027 Leeuwarden, NL",                "HEMA"),
+    ("BCK*PiNutsBV",            "BCK*PiNutsBV BROEK OP LANG, NL",            "PiNutsBV"),
+    ("CCV*GEBAKSKRAAM DE VRI",  "CCV*GEBAKSKRAAM DE VRI LEEUWARDEN, NL",     "GEBAKSKRAAM DE VRI"),
+    ("BCK*Lahore Catering",     "BCK*Lahore Catering Stiens, NL",           "Lahore Catering"),
+    ("BCK*De Landheer t stoe",  "BCK*De Landheer t stoe Anjum, NL",         "De Landheer t stoe"),
+    ("BCK*Huiskamer MP 0172",   "BCK*Huiskamer MP 0172 MEPPEL, NL",         "Huiskamer"),
+    # iDEAL payment request (not a card payment, so no city)
+    ("U. Metselaar via Rabo Betaalverzoek", None,                           "U. Metselaar"),
+]
+
+CITY_CASES = [
+    ("Baylings LEEUWARDEN, NL\n", "LEEUWARDEN"),
+    ("HEMA EV0027 Leeuwarden, NL", "Leeuwarden"),
+    ("BCK*PiNutsBV BROEK OP LANG, NL", "LANG"),
+    ("NL62RABO0377212830 U. Metselaar:High Tea", None),
+    (None, None),
+]
+
+
+def test_clean_rules():
+    for display_name, description, expected in CASES:
+        city = city_from_description(description)
+        got = clean_rules(display_name, city=city)
+        assert got == expected, \
+            "{!r} (city {!r}) -> {!r}, expected {!r}".format(
+                display_name, city, got, expected)
+
+
+def test_city_from_description():
+    for description, expected in CITY_CASES:
+        got = city_from_description(description)
+        assert got == expected, \
+            "{!r} -> {!r}, expected {!r}".format(description, got, expected)
+
+
+def test_never_empty():
+    # A descriptor that is nothing but a stripped prefix must not vanish.
+    assert clean_rules("BCK*")
+    assert clean_rules("") == ""
+    assert clean_rules(None) is None
+
+
+def test_legacy_dash_split():
+    assert clean_rules("Jane Doe - thank you") == "Jane Doe"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS {}".format(name))
+            except AssertionError as e:
+                failures += 1
+                print("FAIL {}: {}".format(name, e))
+    # Show the before/after table for the captured May 29 payments.
+    print("\nBefore -> after (rules):")
+    for display_name, description, _ in CASES:
+        city = city_from_description(description)
+        print("  {:<38} -> {}".format(display_name, clean_rules(display_name, city=city)))
+    raise SystemExit(1 if failures else 0)


### PR DESCRIPTION
Clean noisy bank merchant descriptors before sending them to YNAB: strip payment-processor prefixes (BCK*, CCV*), 'via ...Betaalverzoek' suffixes, city names and store/terminal codes. Configurable via the payee_cleanup setting (none/rules). Refactors map_payment out of map_payments and adds test_payee.py.